### PR TITLE
Disable the minimum number of matches and common code thresholds by default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ struct Args {
     min_matches: usize,
     /// Common code threshold. If the proportion of projects containing some code snippet is greater than this value,
     /// that code will be ignored. The value must be a real number in the range (0, 1].
-    #[arg(short, long, default_value_t = 0.1)]
+    #[arg(short, long, default_value_t = 0.0)]
     common_code_threshold: f64,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ struct Args {
     #[arg(short, long, default_value_t = false)]
     pretty: bool,
     /// Similarity threshold. Pairs of projects with fewer than this number of matches will not be shown.
-    #[arg(short, long, default_value_t = 5)]
+    #[arg(short, long, default_value_t = 0)]
     min_matches: usize,
     /// Common code threshold. If the proportion of projects containing some code snippet is greater than this value,
     /// that code will be ignored. The value must be a real number in the range (0, 1].


### PR DESCRIPTION
There is no point to setting `min-matches` to a value above 0 by default. Even though it may yield a few project pairs that have very few matches, it may also eliminate project pairs with large, valid matches after match expansion.

A similar argument could be made for disabling `common-code-threshold` by default: For a small set of submissions (< 20), the threshold corresponds to < 2 submissions which implies no match gets reported.